### PR TITLE
Add macros for trace event registration with cached IDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DEPS += $(SRCS:.cpp=.d)
 CXXFLAGS ?= --std=c++20
 
 LDFLAGS += -L.
-CXXFLAGS += -I./third_party
+CXXFLAGS += -I./third_party -I./src
 
 
 -include $(TEST_DEPS)

--- a/src/trace_event.h
+++ b/src/trace_event.h
@@ -4,10 +4,10 @@
 
 #include "trace_registry.h"
 
-#define SIMPLETRACE_FIELD_DECL(type, name, dtype) type name;
-#define SIMPLETRACE_FIELD_LAYOUT(type, name, dtype)                            \
-  ::simpletrace::field_layout_t{#name, dtype, offsetof(__trace_this_t, name),  \
-                                sizeof(type)},
+#define SIMPLETRACE_FIELD_DECL(type, name) type name;
+#define SIMPLETRACE_FIELD_LAYOUT(type, name)                                   \
+  ::simpletrace::field_layout_t{#name, ::simpletrace::dtype_of<type>::value,   \
+                                offsetof(__trace_this_t, name), sizeof(type)},
 #define SIMPLETRACE_EVENT_STRUCT(name, FIELDS)                                 \
   struct name {                                                                \
     FIELDS(SIMPLETRACE_FIELD_DECL)                                             \

--- a/src/trace_event.h
+++ b/src/trace_event.h
@@ -1,0 +1,52 @@
+#pragma once
+#include <cstddef>
+#include <optional>
+
+#include "trace_registry.h"
+
+#define SIMPLETRACE_FIELD_DECL(type, name, dtype) type name;
+#define SIMPLETRACE_FIELD_LAYOUT(type, name, dtype)                            \
+  ::simpletrace::field_layout_t{#name, dtype, offsetof(__trace_this_t, name),  \
+                                sizeof(type)},
+#define SIMPLETRACE_EVENT_STRUCT(name, FIELDS)                                 \
+  struct name {                                                                \
+    FIELDS(SIMPLETRACE_FIELD_DECL)                                             \
+    static ::simpletrace::schema_t schema() {                                  \
+      using __trace_this_t = name;                                             \
+      static const ::simpletrace::schema_t s{                                  \
+          #name,                                                               \
+          0,                                                                   \
+          sizeof(__trace_this_t),                                              \
+          alignof(__trace_this_t),                                             \
+          {FIELDS(SIMPLETRACE_FIELD_LAYOUT)}};                                 \
+      return s;                                                                \
+    }                                                                          \
+    static ::simpletrace::event_id_t event_id() {                              \
+      static std::optional<::simpletrace::event_id_t> cached;                  \
+      if (!cached) {                                                           \
+        cached =                                                               \
+            ::simpletrace::trace_registry_t::instance().register_type<name>(); \
+      }                                                                        \
+      return *cached;                                                          \
+    }                                                                          \
+  };
+
+#define SIMPLETRACE_EVENT_STRUCT_STATIC(name, FIELDS)                          \
+  struct name {                                                                \
+    FIELDS(SIMPLETRACE_FIELD_DECL)                                             \
+    static ::simpletrace::schema_t schema() {                                  \
+      using __trace_this_t = name;                                             \
+      static const ::simpletrace::schema_t s{                                  \
+          #name,                                                               \
+          0,                                                                   \
+          sizeof(__trace_this_t),                                              \
+          alignof(__trace_this_t),                                             \
+          {FIELDS(SIMPLETRACE_FIELD_LAYOUT)}};                                 \
+      return s;                                                                \
+    }                                                                          \
+    static ::simpletrace::event_id_t event_id() {                              \
+      static const ::simpletrace::event_id_t cached =                          \
+          ::simpletrace::trace_registry_t::instance().register_type<name>();   \
+      return cached;                                                           \
+    }                                                                          \
+  };

--- a/src/trace_event.h
+++ b/src/trace_event.h
@@ -44,9 +44,6 @@
           {FIELDS(SIMPLETRACE_FIELD_LAYOUT)}};                                 \
       return s;                                                                \
     }                                                                          \
-    static ::simpletrace::event_id_t event_id() {                              \
-      static const ::simpletrace::event_id_t cached =                          \
-          ::simpletrace::trace_registry_t::instance().register_type<name>();   \
-      return cached;                                                           \
-    }                                                                          \
+    inline static const ::simpletrace::event_id_t event_id =                   \
+        ::simpletrace::trace_registry_t::instance().register_type<name>();     \
   };

--- a/src/trace_registry.h
+++ b/src/trace_registry.h
@@ -11,6 +11,28 @@ using event_id_t = uint16_t;
 
 enum class dtype_t { i32, i64, f32, f64, timestamp };
 
+struct timestamp_t {
+  int64_t value;
+};
+
+template <typename T> struct dtype_of;
+
+template <> struct dtype_of<int32_t> {
+  static constexpr dtype_t value = dtype_t::i32;
+};
+template <> struct dtype_of<int64_t> {
+  static constexpr dtype_t value = dtype_t::i64;
+};
+template <> struct dtype_of<float> {
+  static constexpr dtype_t value = dtype_t::f32;
+};
+template <> struct dtype_of<double> {
+  static constexpr dtype_t value = dtype_t::f64;
+};
+template <> struct dtype_of<timestamp_t> {
+  static constexpr dtype_t value = dtype_t::timestamp;
+};
+
 struct field_layout_t {
   std::string_view name;
   dtype_t dtype;

--- a/test/test_trace.cpp
+++ b/test/test_trace.cpp
@@ -3,11 +3,11 @@
 
 using namespace simpletrace;
 
-#define EVENT_A_FIELDS(X) X(int32_t, value, dtype_t::i32)
+#define EVENT_A_FIELDS(X) X(int32_t, value)
 
 SIMPLETRACE_EVENT_STRUCT(event_a_t, EVENT_A_FIELDS)
 
-#define EVENT_B_FIELDS(X) X(int64_t, timestamp, dtype_t::timestamp)
+#define EVENT_B_FIELDS(X) X(timestamp_t, timestamp)
 
 SIMPLETRACE_EVENT_STRUCT_STATIC(event_b_t, EVENT_B_FIELDS)
 

--- a/test/test_trace.cpp
+++ b/test/test_trace.cpp
@@ -17,8 +17,9 @@ void test_event_lazy() {
 }
 
 void test_event_eager() {
-  event_id_t id1 = event_b_t::event_id();
-  TEST_CHECK(id1 == event_b_t::event_id());
+  event_id_t id1 = event_b_t::event_id;
+  event_id_t id2 = trace_registry_t::instance().register_type<event_b_t>();
+  TEST_CHECK(id1 == id2);
 }
 
 TEST_LIST = {{"test_event_lazy", test_event_lazy},

--- a/test/test_trace.cpp
+++ b/test/test_trace.cpp
@@ -1,4 +1,26 @@
 #include "acutest.h"
+#include "trace_event.h"
 
-void test_test() {}
-TEST_LIST = {{"test_test", test_test}, {NULL, NULL}};
+using namespace simpletrace;
+
+#define EVENT_A_FIELDS(X) X(int32_t, value, dtype_t::i32)
+
+SIMPLETRACE_EVENT_STRUCT(event_a_t, EVENT_A_FIELDS)
+
+#define EVENT_B_FIELDS(X) X(int64_t, timestamp, dtype_t::timestamp)
+
+SIMPLETRACE_EVENT_STRUCT_STATIC(event_b_t, EVENT_B_FIELDS)
+
+void test_event_lazy() {
+  event_id_t id1 = event_a_t::event_id();
+  TEST_CHECK(id1 == event_a_t::event_id());
+}
+
+void test_event_eager() {
+  event_id_t id1 = event_b_t::event_id();
+  TEST_CHECK(id1 == event_b_t::event_id());
+}
+
+TEST_LIST = {{"test_event_lazy", test_event_lazy},
+             {"test_event_eager", test_event_eager},
+             {NULL, NULL}};


### PR DESCRIPTION
## Summary
- add `trace_event.h` with macros to declare trace structs and cache their event IDs lazily or at static init
- update tests to exercise new macros for lazy and eager registration
- adjust build flags to find project headers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bd11ad8db883289cb2de5102c28f5e