### PR TITLE
Add CI workflow with GCC, Clang, and valgrind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [g++, clang++]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y g++ clang valgrind
+      - name: Build and test
+        env:
+          CXX: ${{ matrix.compiler }}
+        run: |
+          make clean
+          make test
+
+  valgrind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y g++ valgrind
+      - name: Run tests under valgrind
+        env:
+          PRERUN: "valgrind --error-exitcode=1 --leak-check=full"
+        run: |
+          make clean
+          make test


### PR DESCRIPTION
## Summary
- run `make test` on pull requests with both g++ and clang++
- add valgrind job to execute tests under memory checks

## Testing
- `make format`
- `make clean && make test`


------
https://chatgpt.com/codex/tasks/task_e_68bd88062a48832881d3ceffb932af73