### PR TITLE
Implement trace buffer and add tests

### DIFF
--- a/src/trace_buffer.cpp
+++ b/src/trace_buffer.cpp
@@ -1,61 +1,73 @@
 #include "trace_buffer.h"
 
+#include <cassert>
+#include <cstring>
 #include <limits>
 
-namespace simpletrace{
+namespace simpletrace {
 
-trace_buffer_t::trace_buffer_t(const size_t nbytes) : data_(nbytes), mr_(&data_[0],nbytes,std::pmr::null_memory_resource()), pa_(&mr_),drain_mr_(&data_[0],nbytes,std::pmr::null_memory_resource()),drain_pa_(&drain_mr_) {}
+trace_buffer_t::trace_buffer_t(const size_t nbytes)
+    : data_(nbytes), mr_(&data_[0], nbytes, std::pmr::null_memory_resource()),
+      pa_(&mr_), drain_mr_(&data_[0], nbytes, std::pmr::null_memory_resource()),
+      drain_pa_(&drain_mr_) {}
 
 /*This is the most generic possible behavior with heterogeneous event types.
  *
- * But one could imagine a simple optimization where in the construction of trace_buffer_t we check
- * that all event_types currently registered have the same size and alignment, and a lot of
- * checking done here becomes unnecessary in that case.
+ * But one could imagine a simple optimization where in the construction of
+ * trace_buffer_t we check that all event_types currently registered have the
+ * same size and alignment, and a lot of checking done here becomes unnecessary
+ * in that case.
  *
- * Perhaps more generally we could require all trace events have the same high-ish alignment
- * (e.g. 32 bytes) and size<=max_size, and stick them in constant slots. Either way it is
- * compatible with the below generic implementation and should rather be seen as an optimization
- * or special case.
+ * Perhaps more generally we could require all trace events have the same
+ * high-ish alignment (e.g. 32 bytes) and size<=max_size, and stick them in
+ * constant slots. Either way it is compatible with the below generic
+ * implementation and should rather be seen as an optimization or special case.
  *
  * */
-bool trace_buffer_t::buffer(const event_id_t event,std::span<const std::byte> data) noexcept{
-  assert(data.size()>0);
-  assert(nevents_ < std::numeric_limits<event_id_t>::max() );
-  try{
+bool trace_buffer_t::buffer(const event_id_t event,
+                            std::span<const std::byte> data) noexcept {
+  assert(data.size() > 0);
+  assert(nevents_ < std::numeric_limits<event_id_t>::max());
+  try {
     size_t align = trace_registry_t::instance().schema(event).align;
     size_t size = trace_registry_t::instance().schema(event).size;
     assert(size == data.size());
-    void* event_type_p = pa_.allocate_bytes(sizeof(event_id_t),alignof(event_id_t));
-    *reinterpret_cast<event_id_t*>(event_type_p) = event;
-    void* event_p = pa_.allocate_bytes(size,align);
-    std::memcpy(event_p,&data[0],data.size());
-  } catch(const std::bad_alloc&){
+    void *event_type_p =
+        pa_.allocate_bytes(sizeof(event_id_t), alignof(event_id_t));
+    *reinterpret_cast<event_id_t *>(event_type_p) = event;
+    void *event_p = pa_.allocate_bytes(size, align);
+    std::memcpy(event_p, &data[0], data.size());
+  } catch (const std::bad_alloc &) {
     /*We ran out of space. need to drain events and reset.*/
     return false;
   }
-  nevents_+=1;
+  nevents_ += 1;
   return true;
 }
 
 trace_buffer_t::drained_event_t trace_buffer_t::drain_single() {
-  /*Note I don't catch the possible bad_alloc here. The way this class is set up it shouldn't possibly throw unless
-   * something very bad has happened.*/
-  if(nevents_==0) return {.event = std::numeric_limits<event_id_t>::max(), .data = {}, .events_remaining = 0};
-  event_id_t event = *reinterpret_cast<event_id_t*>(drain_pa_.allocate_bytes(sizeof(event_id_t),alignof(event_id_t)));
+  /*Note I don't catch the possible bad_alloc here. The way this class is set up
+   * it shouldn't possibly throw unless something very bad has happened.*/
+  if (nevents_ == 0)
+    return {.event = std::numeric_limits<event_id_t>::max(),
+            .data = {},
+            .events_remaining = 0};
+  event_id_t event = *reinterpret_cast<event_id_t *>(
+      drain_pa_.allocate_bytes(sizeof(event_id_t), alignof(event_id_t)));
   size_t align = trace_registry_t::instance().schema(event).align;
   size_t size = trace_registry_t::instance().schema(event).size;
-  std::byte* d = reinterpret_cast<std::byte*>(drain_pa_.allocate_bytes(size,align));
-  nevents_-=1;
-  return {.event = event, .data = std::span<const std::byte>(d,size), .events_remaining = nevents_};
+  std::byte *d =
+      reinterpret_cast<std::byte *>(drain_pa_.allocate_bytes(size, align));
+  nevents_ -= 1;
+  return {.event = event,
+          .data = std::span<const std::byte>(d, size),
+          .events_remaining = nevents_};
 }
 
-void trace_buffer_t::reset(){
+void trace_buffer_t::reset() {
   nevents_ = 0;
   mr_.release();
   drain_mr_.release();
 }
 
-
-
-
-}
+} // namespace simpletrace

--- a/src/trace_buffer.h
+++ b/src/trace_buffer.h
@@ -1,38 +1,39 @@
 #pragma once
 #include "trace_registry.h"
 
+#include <cstddef>
 #include <memory_resource>
-namespace simpletrace{
+#include <span>
+#include <vector>
+
+namespace simpletrace {
 
 /*
  * A generic in-memory buffer to be used by actual trace writers
  */
-class trace_buffer_t{
-  public:
-    struct drained_event_t{
-      event_id_t event;
-      std::span<const std::byte> data;
-      size_t events_remaining;
-    };
-    trace_buffer_t(const size_t bytes);
-    bool buffer(const event_id_t event,std::span<const std::byte> data) noexcept;
-    drained_event_t drain_single();
+class trace_buffer_t {
+public:
+  struct drained_event_t {
+    event_id_t event;
+    std::span<const std::byte> data;
+    size_t events_remaining;
+  };
+  trace_buffer_t(const size_t bytes);
+  bool buffer(const event_id_t event, std::span<const std::byte> data) noexcept;
+  drained_event_t drain_single();
 
-    void reset();
+  void reset();
 
-  private: 
-    size_t nevents_ = 0;
-    std::vector<std::byte> data_;
-    std::pmr::monotonic_buffer_resource mr_;
-    std::pmr::polymorphic_allocator<std::byte> pa_;
+private:
+  size_t nevents_ = 0;
+  std::vector<std::byte> data_;
+  std::pmr::monotonic_buffer_resource mr_;
+  std::pmr::polymorphic_allocator<std::byte> pa_;
 
-    /*Recover data by grabbing pointers out of the same buffer in the same
-     * order we allocated them.*/
-    std::pmr::monotonic_buffer_resource drain_mr_;
-    std::pmr::polymorphic_allocator<std::byte> drain_pa_;
-
-
-
+  /*Recover data by grabbing pointers out of the same buffer in the same
+   * order we allocated them.*/
+  std::pmr::monotonic_buffer_resource drain_mr_;
+  std::pmr::polymorphic_allocator<std::byte> drain_pa_;
 };
 
-}
+} // namespace simpletrace

--- a/test/test_trace_buffer.cpp
+++ b/test/test_trace_buffer.cpp
@@ -1,0 +1,61 @@
+#include "acutest.h"
+#include "trace_buffer.h"
+#include "trace_event.h"
+
+#include <cstring>
+#include <limits>
+
+using namespace simpletrace;
+
+#define TEST_EVENT_FIELDS(X) X(int32_t, value)
+SIMPLETRACE_EVENT_STRUCT(test_event_t, TEST_EVENT_FIELDS)
+
+static std::span<const std::byte> as_bytes(const test_event_t &e) {
+  return {reinterpret_cast<const std::byte *>(&e), sizeof(e)};
+}
+
+void test_buffer_and_drain() {
+  trace_buffer_t buf(1024);
+
+  test_event_t e1{.value = 1};
+  TEST_CHECK(buf.buffer(test_event_t::event_id(), as_bytes(e1)));
+
+  test_event_t e2{.value = 2};
+  TEST_CHECK(buf.buffer(test_event_t::event_id(), as_bytes(e2)));
+
+  auto first = buf.drain_single();
+  test_event_t out1;
+  std::memcpy(&out1, first.data.data(), first.data.size());
+  TEST_CHECK(first.event == test_event_t::event_id());
+  TEST_CHECK(out1.value == 1);
+  TEST_CHECK(first.events_remaining == 1);
+
+  auto second = buf.drain_single();
+  test_event_t out2;
+  std::memcpy(&out2, second.data.data(), second.data.size());
+  TEST_CHECK(second.event == test_event_t::event_id());
+  TEST_CHECK(out2.value == 2);
+  TEST_CHECK(second.events_remaining == 0);
+
+  auto empty = buf.drain_single();
+  TEST_CHECK(empty.event == std::numeric_limits<event_id_t>::max());
+  TEST_CHECK(empty.events_remaining == 0);
+}
+
+void test_buffer_overflow() {
+  const auto &schema =
+      trace_registry_t::instance().schema(test_event_t::event_id());
+  const size_t bytes_for_one = sizeof(event_id_t) + schema.size + schema.align;
+  trace_buffer_t buf(bytes_for_one);
+
+  test_event_t e{.value = 123};
+  TEST_CHECK(buf.buffer(test_event_t::event_id(), as_bytes(e)));
+  TEST_CHECK(!buf.buffer(test_event_t::event_id(), as_bytes(e)));
+
+  buf.reset();
+  TEST_CHECK(buf.buffer(test_event_t::event_id(), as_bytes(e)));
+}
+
+TEST_LIST = {{"test_buffer_and_drain", test_buffer_and_drain},
+             {"test_buffer_overflow", test_buffer_overflow},
+             {NULL, NULL}};


### PR DESCRIPTION
## Summary
- complete trace buffer implementation using pmr memory resources
- add unit tests for buffer draining and overflow handling

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bdba0acdb4832889e3348ca56e3ae0