### PR TITLE
Add buffered NDJSON trace writer

### DIFF
--- a/src/ndjson_trace_writer.cpp
+++ b/src/ndjson_trace_writer.cpp
@@ -1,0 +1,87 @@
+#include "ndjson_trace_writer.h"
+
+#include <limits>
+#include <string_view>
+
+namespace simpletrace {
+
+ndjson_trace_writer_t::ndjson_trace_writer_t(const std::string &filename,
+                                             size_t buffer_bytes)
+    : out_(filename), buffer_(buffer_bytes) {}
+
+ndjson_trace_writer_t::~ndjson_trace_writer_t() { flush(); }
+
+void ndjson_trace_writer_t::write(const event_id_t event,
+                                  std::span<const std::byte> data) {
+  if (!buffer_.buffer(event, data)) {
+    flush_buffer();
+    buffer_.reset();
+    buffer_.buffer(event, data);
+  }
+}
+
+void ndjson_trace_writer_t::flush() {
+  flush_buffer();
+  out_.flush();
+}
+
+void ndjson_trace_writer_t::flush_buffer() {
+  while (true) {
+    auto e = buffer_.drain_single();
+    if (e.event == std::numeric_limits<event_id_t>::max())
+      break;
+    write_event(e);
+  }
+}
+
+void ndjson_trace_writer_t::write_event(
+    const trace_buffer_t::drained_event_t &e) {
+  const auto &schema = trace_registry_t::instance().schema(e.event);
+  out_ << "{\"event_type\":\"" << schema.name << "\"";
+  const std::byte *base = e.data.data();
+  for (const auto &field : schema.fields) {
+    out_ << ",\"" << field.name << "\":";
+    const std::byte *ptr = base + field.offset;
+    switch (field.dtype) {
+    case dtype_t::i32:
+      out_ << *reinterpret_cast<const int32_t *>(ptr);
+      break;
+    case dtype_t::i64:
+      out_ << *reinterpret_cast<const int64_t *>(ptr);
+      break;
+    case dtype_t::f32:
+      out_ << *reinterpret_cast<const float *>(ptr);
+      break;
+    case dtype_t::f64:
+      out_ << *reinterpret_cast<const double *>(ptr);
+      break;
+    case dtype_t::timestamp:
+      out_ << reinterpret_cast<const timestamp_t *>(ptr)->dur;
+      break;
+    case dtype_t::string_view: {
+      auto sv = *reinterpret_cast<const std::string_view *>(ptr);
+      out_ << "\"" << escape_string(sv) << "\"";
+      break;
+    }
+    case dtype_t::scope_token: {
+      auto tok = *reinterpret_cast<const scope_token_t *>(ptr);
+      out_ << (tok == scope_token_t::beg ? "\"beg\"" : "\"end\"");
+      break;
+    }
+    }
+  }
+  out_ << "}\n";
+}
+
+std::string ndjson_trace_writer_t::escape_string(std::string_view sv) {
+  std::string out;
+  out.reserve(sv.size());
+  for (char c : sv) {
+    if (c == '"' || c == '\\')
+      out.push_back('\\');
+    out.push_back(c);
+  }
+  return out;
+}
+
+} // namespace simpletrace

--- a/src/ndjson_trace_writer.h
+++ b/src/ndjson_trace_writer.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "trace_buffer.h"
+#include "trace_writer.h"
+
+#include <fstream>
+#include <string>
+
+namespace simpletrace {
+
+class ndjson_trace_writer_t : public trace_writer_t {
+public:
+  ndjson_trace_writer_t(const std::string &filename, size_t buffer_bytes);
+  ~ndjson_trace_writer_t() override;
+
+  void write(const event_id_t event, std::span<const std::byte> data) override;
+  void flush() override;
+
+private:
+  void flush_buffer();
+  void write_event(const trace_buffer_t::drained_event_t &e);
+  static std::string escape_string(std::string_view sv);
+
+  std::ofstream out_;
+  trace_buffer_t buffer_;
+};
+
+} // namespace simpletrace

--- a/src/trace_writer.h
+++ b/src/trace_writer.h
@@ -10,10 +10,11 @@ public:
   virtual void write(const event_id_t event,
                      std::span<const std::byte> data) = 0;
   virtual void flush() = 0;
+  virtual ~trace_writer_t() = default;
   /*Can write a concept for T.*/
-  template<typename T>
-  void write_type(const T& x){
-    write(T::event_id,std::span<const std::byte>(reinterpret_cast<const std::byte*>(&x,sizeof(T))));
+  template <typename T> void write_type(const T &x) {
+    write(T::event_id, std::span<const std::byte>(
+                           reinterpret_cast<const std::byte *>(&x, sizeof(T))));
   }
 };
 

--- a/test/test_ndjson_writer.cpp
+++ b/test/test_ndjson_writer.cpp
@@ -1,0 +1,43 @@
+#include "acutest.h"
+#include "ndjson_trace_writer.h"
+#include "trace_event.h"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using namespace simpletrace;
+
+#define TEST_EVENT_FIELDS(X) X(int32_t, value)
+SIMPLETRACE_EVENT_STRUCT(test_event_t, TEST_EVENT_FIELDS)
+
+static std::span<const std::byte> as_bytes(const test_event_t &e) {
+  return {reinterpret_cast<const std::byte *>(&e), sizeof(e)};
+}
+
+void test_ndjson_flush() {
+  const auto &schema =
+      trace_registry_t::instance().schema(test_event_t::event_id());
+  const size_t bytes_for_one = sizeof(event_id_t) + schema.size + schema.align;
+  auto tmp = std::filesystem::temp_directory_path() / "simpletrace_test.ndjson";
+  std::filesystem::remove(tmp);
+  ndjson_trace_writer_t w(tmp.string(), bytes_for_one);
+
+  test_event_t e1{.value = 1};
+  w.write(test_event_t::event_id(), as_bytes(e1));
+  test_event_t e2{.value = 2};
+  w.write(test_event_t::event_id(), as_bytes(e2));
+  w.flush();
+
+  std::ifstream in(tmp);
+  std::string line;
+  std::getline(in, line);
+  TEST_CHECK(line.find("\"event_type\":\"test_event_t\"") != std::string::npos);
+  TEST_CHECK(line.find("\"value\":1") != std::string::npos);
+  std::getline(in, line);
+  TEST_CHECK(line.find("\"value\":2") != std::string::npos);
+  TEST_CHECK(!std::getline(in, line));
+  std::filesystem::remove(tmp);
+}
+
+TEST_LIST = {{"test_ndjson_flush", test_ndjson_flush}, {NULL, NULL}};


### PR DESCRIPTION
## Summary
- add concrete trace writer that buffers events and writes NDJSON when full
- ensure interface has virtual destructor
- test ndjson writer flushing behavior

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc26258d48328ad6567118e7887d4