### PR TITLE
Add scoped trace event and RAII helper

### DIFF
--- a/src/scoped_trace.cpp
+++ b/src/scoped_trace.cpp
@@ -1,0 +1,5 @@
+#include "scoped_trace.h"
+
+namespace simpletrace {
+thread_local trace_writer_t *tls_writer = nullptr;
+}

--- a/src/scoped_trace.h
+++ b/src/scoped_trace.h
@@ -1,0 +1,51 @@
+#pragma once
+#include "trace_scope_event.h"
+#include "trace_writer.h"
+#include <chrono>
+#include <string_view>
+
+namespace simpletrace {
+
+extern thread_local trace_writer_t *tls_writer;
+
+inline timestamp_t now_timestamp() {
+  timestamp_t ts;
+  ts.dur = std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+               .count();
+  return ts;
+}
+
+class scoped_trace_t {
+public:
+  scoped_trace_t(trace_writer_t *writer, std::string_view label)
+      : writer_(writer), label_(label), start_(now_timestamp()) {
+    if (writer_) {
+      scope_trace_event_t ev{scope_token_t::beg, label_, start_};
+      writer_->write(scope_trace_event_t::event_id,
+                     std::span<const std::byte>(
+                         reinterpret_cast<const std::byte *>(&ev), sizeof(ev)));
+    }
+  }
+  ~scoped_trace_t() {
+    if (writer_) {
+      scope_trace_event_t ev{scope_token_t::end, label_, now_timestamp()};
+      writer_->write(scope_trace_event_t::event_id,
+                     std::span<const std::byte>(
+                         reinterpret_cast<const std::byte *>(&ev), sizeof(ev)));
+    }
+  }
+
+private:
+  trace_writer_t *writer_;
+  std::string_view label_;
+  timestamp_t start_;
+};
+
+#define SIMPLETRACE_CONCAT_INNER(x, y) x##y
+#define SIMPLETRACE_CONCAT(x, y) SIMPLETRACE_CONCAT_INNER(x, y)
+#define SIMPLETRACE_SCOPED_TRACE(label)                                        \
+  ::simpletrace::scoped_trace_t SIMPLETRACE_CONCAT(                            \
+      __simpletrace_scoped_, __LINE__)(::simpletrace::tls_writer, label)
+
+} // namespace simpletrace

--- a/src/trace_scope_event.h
+++ b/src/trace_scope_event.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "trace_event.h"
+
+namespace simpletrace {
+
+#define TRACE_SCOPE_EVENT_FIELDS(X)                                            \
+  X(scope_token_t, token)                                                      \
+  X(std::string_view, label)                                                   \
+  X(timestamp_t, timestamp)
+
+SIMPLETRACE_EVENT_STRUCT_STATIC(scope_trace_event_t, TRACE_SCOPE_EVENT_FIELDS)
+
+} // namespace simpletrace

--- a/test/test_scoped_trace.cpp
+++ b/test/test_scoped_trace.cpp
@@ -1,0 +1,35 @@
+#include "acutest.h"
+#include "scoped_trace.h"
+#include <vector>
+
+using namespace simpletrace;
+using namespace std::literals;
+
+struct vector_writer_t : trace_writer_t {
+  std::vector<scope_trace_event_t> events;
+  void write(const event_id_t event, std::span<const std::byte> data) override {
+    if (event == scope_trace_event_t::event_id) {
+      events.push_back(
+          *reinterpret_cast<const scope_trace_event_t *>(data.data()));
+    }
+  }
+  void flush() override {}
+};
+
+void test_scoped_trace_basic() {
+  vector_writer_t writer;
+  tls_writer = &writer;
+  {
+    SIMPLETRACE_SCOPED_TRACE("hello"sv);
+  }
+  tls_writer = nullptr;
+  TEST_CHECK(writer.events.size() == 2);
+  TEST_CHECK(writer.events[0].token == scope_token_t::beg);
+  TEST_CHECK(writer.events[1].token == scope_token_t::end);
+  TEST_CHECK(writer.events[0].label == "hello"sv);
+  TEST_CHECK(writer.events[1].label == "hello"sv);
+  TEST_CHECK(writer.events[0].timestamp.dur <= writer.events[1].timestamp.dur);
+}
+
+TEST_LIST = {{"test_scoped_trace_basic", test_scoped_trace_basic},
+             {NULL, NULL}};


### PR DESCRIPTION
## Summary
- Add scope_trace_event_t for begin/end scope markers
- Introduce scoped_trace_t RAII helper and SIMPLETRACE_SCOPED_TRACE macro
- Provide thread-local writer hook and unit test for scoped tracing

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc4182dfc83288cb0d1c49cc4b38d