### PR TITLE
Remove lazy event type

### DIFF
--- a/src/trace_event.h
+++ b/src/trace_event.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <cstddef>
-#include <optional>
 
 #include "trace_registry.h"
 
@@ -21,32 +20,6 @@
           {FIELDS(SIMPLETRACE_FIELD_LAYOUT)}};                                 \
       return s;                                                                \
     }                                                                          \
-    static ::simpletrace::event_id_t event_id() {                              \
-      static std::optional<::simpletrace::event_id_t> cached;                  \
-      if (!cached) {                                                           \
-        cached =                                                               \
-            ::simpletrace::trace_registry_t::instance().register_type<name>(); \
-      }                                                                        \
-      return *cached;                                                          \
-    }                                                                          \
-  };
-
-#define SIMPLETRACE_EVENT_STRUCT_STATIC(name, FIELDS)                          \
-  struct name {                                                                \
-    FIELDS(SIMPLETRACE_FIELD_DECL)                                             \
-    static ::simpletrace::schema_t schema() {                                  \
-      using __trace_this_t = name;                                             \
-      static const ::simpletrace::schema_t s{                                  \
-          #name,                                                               \
-          0,                                                                   \
-          sizeof(__trace_this_t),                                              \
-          alignof(__trace_this_t),                                             \
-          {FIELDS(SIMPLETRACE_FIELD_LAYOUT)}};                                 \
-      return s;                                                                \
-    }                                                                          \
     inline static const ::simpletrace::event_id_t event_id =                   \
         ::simpletrace::trace_registry_t::instance().register_type<name>();     \
   };
-
-
-

--- a/src/trace_scope_event.h
+++ b/src/trace_scope_event.h
@@ -8,6 +8,6 @@ namespace simpletrace {
   X(std::string_view, label)                                                   \
   X(timestamp_t, timestamp)
 
-SIMPLETRACE_EVENT_STRUCT_STATIC(scope_trace_event_t, TRACE_SCOPE_EVENT_FIELDS)
+SIMPLETRACE_EVENT_STRUCT(scope_trace_event_t, TRACE_SCOPE_EVENT_FIELDS)
 
 } // namespace simpletrace

--- a/test/test_ndjson_writer.cpp
+++ b/test/test_ndjson_writer.cpp
@@ -17,16 +17,16 @@ static std::span<const std::byte> as_bytes(const test_event_t &e) {
 
 void test_ndjson_flush() {
   const auto &schema =
-      trace_registry_t::instance().schema(test_event_t::event_id());
+      trace_registry_t::instance().schema(test_event_t::event_id);
   const size_t bytes_for_one = sizeof(event_id_t) + schema.size + schema.align;
   auto tmp = std::filesystem::temp_directory_path() / "simpletrace_test.ndjson";
   std::filesystem::remove(tmp);
   ndjson_trace_writer_t w(tmp.string(), bytes_for_one);
 
   test_event_t e1{.value = 1};
-  w.write(test_event_t::event_id(), as_bytes(e1));
+  w.write(test_event_t::event_id, as_bytes(e1));
   test_event_t e2{.value = 2};
-  w.write(test_event_t::event_id(), as_bytes(e2));
+  w.write(test_event_t::event_id, as_bytes(e2));
   w.flush();
 
   std::ifstream in(tmp);

--- a/test/test_trace.cpp
+++ b/test/test_trace.cpp
@@ -3,25 +3,14 @@
 
 using namespace simpletrace;
 
-#define EVENT_A_FIELDS(X) X(int32_t, value)
-
-SIMPLETRACE_EVENT_STRUCT(event_a_t, EVENT_A_FIELDS)
-
 #define EVENT_B_FIELDS(X) X(timestamp_t, timestamp)
 
-SIMPLETRACE_EVENT_STRUCT_STATIC(event_b_t, EVENT_B_FIELDS)
+SIMPLETRACE_EVENT_STRUCT(event_b_t, EVENT_B_FIELDS)
 
-void test_event_lazy() {
-  event_id_t id1 = event_a_t::event_id();
-  TEST_CHECK(id1 == event_a_t::event_id());
-}
-
-void test_event_eager() {
+void test_event_static() {
   event_id_t id1 = event_b_t::event_id;
   event_id_t id2 = trace_registry_t::instance().register_type<event_b_t>();
   TEST_CHECK(id1 == id2);
 }
 
-TEST_LIST = {{"test_event_lazy", test_event_lazy},
-             {"test_event_eager", test_event_eager},
-             {NULL, NULL}};
+TEST_LIST = {{"test_event_static", test_event_static}, {NULL, NULL}};

--- a/test/test_trace_buffer.cpp
+++ b/test/test_trace_buffer.cpp
@@ -18,22 +18,22 @@ void test_buffer_and_drain() {
   trace_buffer_t buf(1024);
 
   test_event_t e1{.value = 1};
-  TEST_CHECK(buf.buffer(test_event_t::event_id(), as_bytes(e1)));
+  TEST_CHECK(buf.buffer(test_event_t::event_id, as_bytes(e1)));
 
   test_event_t e2{.value = 2};
-  TEST_CHECK(buf.buffer(test_event_t::event_id(), as_bytes(e2)));
+  TEST_CHECK(buf.buffer(test_event_t::event_id, as_bytes(e2)));
 
   auto first = buf.drain_single();
   test_event_t out1;
   std::memcpy(&out1, first.data.data(), first.data.size());
-  TEST_CHECK(first.event == test_event_t::event_id());
+  TEST_CHECK(first.event == test_event_t::event_id);
   TEST_CHECK(out1.value == 1);
   TEST_CHECK(first.events_remaining == 1);
 
   auto second = buf.drain_single();
   test_event_t out2;
   std::memcpy(&out2, second.data.data(), second.data.size());
-  TEST_CHECK(second.event == test_event_t::event_id());
+  TEST_CHECK(second.event == test_event_t::event_id);
   TEST_CHECK(out2.value == 2);
   TEST_CHECK(second.events_remaining == 0);
 
@@ -44,16 +44,16 @@ void test_buffer_and_drain() {
 
 void test_buffer_overflow() {
   const auto &schema =
-      trace_registry_t::instance().schema(test_event_t::event_id());
+      trace_registry_t::instance().schema(test_event_t::event_id);
   const size_t bytes_for_one = sizeof(event_id_t) + schema.size + schema.align;
   trace_buffer_t buf(bytes_for_one);
 
   test_event_t e{.value = 123};
-  TEST_CHECK(buf.buffer(test_event_t::event_id(), as_bytes(e)));
-  TEST_CHECK(!buf.buffer(test_event_t::event_id(), as_bytes(e)));
+  TEST_CHECK(buf.buffer(test_event_t::event_id, as_bytes(e)));
+  TEST_CHECK(!buf.buffer(test_event_t::event_id, as_bytes(e)));
 
   buf.reset();
-  TEST_CHECK(buf.buffer(test_event_t::event_id(), as_bytes(e)));
+  TEST_CHECK(buf.buffer(test_event_t::event_id, as_bytes(e)));
 }
 
 TEST_LIST = {{"test_buffer_and_drain", test_buffer_and_drain},


### PR DESCRIPTION
## Summary
- remove the lazy event struct macro so only the static event form remains
- update scope tracing event and tests to use the static event ID
- drop the unused lazy event test

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc89bc9208328b544827a6b342abb