### PR TITLE
docs: add quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,38 @@ This is more of a simple library to help with my own tracing needs within person
 
 The idea being that basic tracing is supported, but that we could add arbitrary data on an ad-hoc
 basis that could be immediately understood by consumers (trace sinks & writers).
+
+## Quick start
+
+### Basic scoped trace
+```c++
+#include "scoped_trace.h"
+#include "ndjson_trace_writer.h"
+
+int main() {
+  using namespace simpletrace;
+  ndjson_trace_writer_t writer{"trace.json", 1 << 20};
+  impl::set_tls_writer(&writer);
+  {
+    SIMPLETRACE_SCOPED_TRACE("doing work");
+    // ... your code ...
+  }
+  writer.flush();
+}
+```
+This writes a beginning and end `scope_trace_event_t` for the labeled block.
+
+### Custom events
+Define a struct with the provided macros to describe the fields of the event.
+```c++
+#define MY_EVENT_FIELDS(X) \
+  X(int32_t, answer) \
+  X(std::string_view, message)
+SIMPLETRACE_EVENT_STRUCT(my_event_t, MY_EVENT_FIELDS);
+```
+Emitting the event is then just:
+```c++
+my_event_t e{.answer = 42, .message = "hello"};
+writer.write_type(e);
+```
+The macro registers the type with `trace_registry_t`, so readers know how to decode the bytes.


### PR DESCRIPTION
## Summary
- add a quick start guide showing scoped trace usage
- document how to define and emit custom event types

## Testing
- `make format`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bdcea9e5c8832889094bafc759d39c