### PR TITLE
Fix std::byte span creation in write_type

### DIFF
--- a/src/trace_writer.h
+++ b/src/trace_writer.h
@@ -14,7 +14,7 @@ public:
   /*Can write a concept for T.*/
   template <typename T> void write_type(const T &x) {
     write(T::event_id, std::span<const std::byte>(
-                           reinterpret_cast<const std::byte *>(&x, sizeof(T))));
+                           reinterpret_cast<const std::byte *>(&x), sizeof(T)));
   }
 };
 


### PR DESCRIPTION
## Summary
- Correct span construction in `trace_writer_t::write_type` by casting to `std::byte` pointer and using `sizeof(T)`

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bf1edca5808328aa1e9419ac339292