### PR TITLE
Escape control characters in NDJSON writer

### DIFF
--- a/src/ndjson_trace_writer.cpp
+++ b/src/ndjson_trace_writer.cpp
@@ -76,10 +76,38 @@ void ndjson_trace_writer_t::write_event(
 std::string ndjson_trace_writer_t::escape_string(std::string_view sv) {
   std::string out;
   out.reserve(sv.size());
-  for (char c : sv) {
-    if (c == '"' || c == '\\')
-      out.push_back('\\');
-    out.push_back(c);
+  for (unsigned char c : sv) {
+    switch (c) {
+    case '"':
+      out += "\\\"";
+      break;
+    case '\\':
+      out += "\\\\";
+      break;
+    case '\b':
+      out += "\\b";
+      break;
+    case '\f':
+      out += "\\f";
+      break;
+    case '\n':
+      out += "\\n";
+      break;
+    case '\r':
+      out += "\\r";
+      break;
+    case '\t':
+      out += "\\t";
+      break;
+    default:
+      if (c < 0x20) {
+        static const char hex[] = "0123456789abcdef";
+        char buf[7] = {'\\', 'u', '0', '0', hex[c >> 4], hex[c & 0xf], '\0'};
+        out.append(buf, 6);
+      } else {
+        out.push_back(static_cast<char>(c));
+      }
+    }
   }
   return out;
 }

--- a/test/test_ndjson_writer.cpp
+++ b/test/test_ndjson_writer.cpp
@@ -5,13 +5,17 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <string_view>
 
 using namespace simpletrace;
 
 #define TEST_EVENT_FIELDS(X) X(int32_t, value)
 SIMPLETRACE_EVENT_STRUCT(test_event_t, TEST_EVENT_FIELDS)
 
-static std::span<const std::byte> as_bytes(const test_event_t &e) {
+#define ESCAPE_EVENT_FIELDS(X) X(std::string_view, text)
+SIMPLETRACE_EVENT_STRUCT(escape_event_t, ESCAPE_EVENT_FIELDS)
+
+template <typename T> static std::span<const std::byte> as_bytes(const T &e) {
   return {reinterpret_cast<const std::byte *>(&e), sizeof(e)};
 }
 
@@ -40,4 +44,31 @@ void test_ndjson_flush() {
   std::filesystem::remove(tmp);
 }
 
-TEST_LIST = {{"test_ndjson_flush", test_ndjson_flush}, {NULL, NULL}};
+void test_ndjson_escape_control_chars() {
+  const auto &schema =
+      trace_registry_t::instance().schema(escape_event_t::event_id);
+  const size_t bytes_for_one = sizeof(event_id_t) + schema.size + schema.align;
+  auto tmp =
+      std::filesystem::temp_directory_path() / "simpletrace_escape_test.ndjson";
+  std::filesystem::remove(tmp);
+  ndjson_trace_writer_t w(tmp.string(), bytes_for_one);
+
+  std::string text = "line1\nline2\rline3\tline4\bline5\fline6";
+  text.push_back('\x01');
+  escape_event_t e{.text = text};
+  w.write(escape_event_t::event_id, as_bytes(e));
+  w.flush();
+
+  std::ifstream in(tmp);
+  std::string line;
+  std::getline(in, line);
+  std::string expected =
+      "\"text\":\"line1\\nline2\\rline3\\tline4\\bline5\\fline6\\u0001\"";
+  TEST_CHECK(line.find(expected) != std::string::npos);
+  std::filesystem::remove(tmp);
+}
+
+TEST_LIST = {
+    {"test_ndjson_flush", test_ndjson_flush},
+    {"test_ndjson_escape_control_chars", test_ndjson_escape_control_chars},
+    {NULL, NULL}};


### PR DESCRIPTION
## Summary
- Escape control characters when writing strings to NDJSON
- Add unit test verifying JSON-escaped control characters

## Testing
- `make format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bf1f41d0388328be77fb80a7c7275e