### PR TITLE
Enforce string literal labels for scoped traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,17 @@ basis that could be immediately understood by consumers (trace sinks & writers).
 int main() {
   using namespace simpletrace;
   ndjson_trace_writer_t writer{"trace.json", 1 << 20};
-  impl::set_tls_writer(&writer);
-  {
-    SIMPLETRACE_SCOPED_TRACE("doing work");
-    // ... your code ...
-  }
-  writer.flush();
+    impl::set_tls_writer(&writer);
+    {
+      SIMPLETRACE_SCOPED_TRACE("doing work");
+      // ... your code ...
+    }
+    writer.flush();
 }
 ```
-This writes a beginning and end `scope_trace_event_t` for the labeled block.
+This writes a beginning and end `scope_trace_event_t` for the labeled block. The
+label must be a string literal (or other static storage string) so no string
+data is copied.
 
 ### Custom events
 Define a struct with the provided macros to describe the fields of the event.

--- a/src/scoped_trace.cpp
+++ b/src/scoped_trace.cpp
@@ -2,7 +2,7 @@
 #include <chrono>
 
 namespace simpletrace {
-namespace {
+namespace impl {
 timestamp_t now_timestamp() {
   timestamp_t ts;
   ts.dur = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -10,21 +10,11 @@ timestamp_t now_timestamp() {
                .count();
   return ts;
 }
-} // namespace
-
-scoped_trace_t::scoped_trace_t(trace_writer_t *writer, std::string_view label)
-    : writer_(writer), label_(label), start_(now_timestamp()) {
-  if (writer_) {
-    scope_trace_event_t ev{scope_token_t::beg, label_, start_};
-    writer_->write(scope_trace_event_t::event_id,
-                   std::span<const std::byte>(
-                       reinterpret_cast<const std::byte *>(&ev), sizeof(ev)));
-  }
-}
+} // namespace impl
 
 scoped_trace_t::~scoped_trace_t() {
   if (writer_) {
-    scope_trace_event_t ev{scope_token_t::end, label_, now_timestamp()};
+    scope_trace_event_t ev{scope_token_t::end, label_, impl::now_timestamp()};
     writer_->write(scope_trace_event_t::event_id,
                    std::span<const std::byte>(
                        reinterpret_cast<const std::byte *>(&ev), sizeof(ev)));

--- a/src/scoped_trace.cpp
+++ b/src/scoped_trace.cpp
@@ -12,6 +12,16 @@ timestamp_t now_timestamp() {
 }
 } // namespace impl
 
+scoped_trace_t::scoped_trace_t(trace_writer_t *writer, std::string_view label)
+    : writer_(writer), label_(label), start_(impl::now_timestamp()) {
+  if (writer_) {
+    scope_trace_event_t ev{scope_token_t::beg, label_, start_};
+    writer_->write(scope_trace_event_t::event_id,
+                   std::span<const std::byte>(
+                       reinterpret_cast<const std::byte *>(&ev), sizeof(ev)));
+  }
+}
+
 scoped_trace_t::~scoped_trace_t() {
   if (writer_) {
     scope_trace_event_t ev{scope_token_t::end, label_, impl::now_timestamp()};

--- a/src/scoped_trace.h
+++ b/src/scoped_trace.h
@@ -14,17 +14,11 @@ class scoped_trace_t {
 public:
   template <std::size_t N>
   scoped_trace_t(trace_writer_t *writer, const char (&label)[N])
-      : writer_(writer), label_(label, N - 1), start_(impl::now_timestamp()) {
-    if (writer_) {
-      scope_trace_event_t ev{scope_token_t::beg, label_, start_};
-      writer_->write(scope_trace_event_t::event_id,
-                     std::span<const std::byte>(
-                         reinterpret_cast<const std::byte *>(&ev), sizeof(ev)));
-    }
-  }
+      : scoped_trace_t(writer, std::string_view(label, N - 1)) {}
   ~scoped_trace_t();
 
 private:
+  scoped_trace_t(trace_writer_t *writer, std::string_view label);
   trace_writer_t *writer_;
   std::string_view label_;
   timestamp_t start_;

--- a/src/scoped_trace.h
+++ b/src/scoped_trace.h
@@ -6,9 +6,22 @@
 
 namespace simpletrace {
 
+namespace impl {
+timestamp_t now_timestamp();
+} // namespace impl
+
 class scoped_trace_t {
 public:
-  scoped_trace_t(trace_writer_t *writer, std::string_view label);
+  template <std::size_t N>
+  scoped_trace_t(trace_writer_t *writer, const char (&label)[N])
+      : writer_(writer), label_(label, N - 1), start_(impl::now_timestamp()) {
+    if (writer_) {
+      scope_trace_event_t ev{scope_token_t::beg, label_, start_};
+      writer_->write(scope_trace_event_t::event_id,
+                     std::span<const std::byte>(
+                         reinterpret_cast<const std::byte *>(&ev), sizeof(ev)));
+    }
+  }
   ~scoped_trace_t();
 
 private:

--- a/src/trace_scope_event.h
+++ b/src/trace_scope_event.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "trace_event.h"
+#include <string_view>
 
 namespace simpletrace {
 

--- a/test/test_scoped_trace.cpp
+++ b/test/test_scoped_trace.cpp
@@ -1,10 +1,17 @@
 #include "acutest.h"
 #include "scoped_trace.h"
 #include "thread_local_writer.h"
+#include <string>
+#include <type_traits>
 #include <vector>
 
 using namespace simpletrace;
 using namespace std::literals;
+
+static_assert(!std::is_constructible_v<scoped_trace_t, trace_writer_t *,
+                                       std::string_view>);
+static_assert(
+    !std::is_constructible_v<scoped_trace_t, trace_writer_t *, std::string>);
 
 struct vector_writer_t : trace_writer_t {
   std::vector<scope_trace_event_t> events;
@@ -21,7 +28,7 @@ void test_scoped_trace_basic() {
   vector_writer_t writer;
   impl::set_tls_writer(&writer);
   {
-    SIMPLETRACE_SCOPED_TRACE("hello"sv);
+    SIMPLETRACE_SCOPED_TRACE("hello");
   }
   impl::set_tls_writer(nullptr);
   TEST_CHECK(writer.events.size() == 2);


### PR DESCRIPTION
## Summary
- require scoped_trace_t labels be string literals via templated constructor
- document static label requirement and update tests
- include string_view in trace_scope_event for clarity

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bf1f33057883288e63c7682d117c88