### PR TITLE
Check NDJSON writer stream after opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ int main() {
 ```
 This writes a beginning and end `scope_trace_event_t` for the labeled block.
 
+If the output file cannot be opened or the stream is otherwise invalid during
+construction, `ndjson_trace_writer_t` throws a `std::runtime_error`.
+
 ### Custom events
 Define a struct with the provided macros to describe the fields of the event.
 ```c++

--- a/src/ndjson_trace_writer.cpp
+++ b/src/ndjson_trace_writer.cpp
@@ -1,13 +1,18 @@
 #include "ndjson_trace_writer.h"
 
 #include <limits>
+#include <stdexcept>
 #include <string_view>
 
 namespace simpletrace {
 
 ndjson_trace_writer_t::ndjson_trace_writer_t(const std::string &filename,
                                              size_t buffer_bytes)
-    : out_(filename), buffer_(buffer_bytes) {}
+    : out_(filename), buffer_(buffer_bytes) {
+  if (!out_.is_open() || !out_.good()) {
+    throw std::runtime_error("failed to open file " + filename);
+  }
+}
 
 ndjson_trace_writer_t::~ndjson_trace_writer_t() { flush(); }
 


### PR DESCRIPTION
## Summary
- Validate NDJSON writer stream on construction and throw a runtime error if the file can't be opened
- Document ndjson trace writer stream failure behavior in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bf1f4fed50832889f50b296ffef224