### PR TITLE
Mark trace_buffer::buffer as nodiscard

### DIFF
--- a/src/ndjson_trace_writer.cpp
+++ b/src/ndjson_trace_writer.cpp
@@ -1,5 +1,6 @@
 #include "ndjson_trace_writer.h"
 
+#include <cassert>
 #include <limits>
 #include <string_view>
 
@@ -16,7 +17,8 @@ void ndjson_trace_writer_t::write(const event_id_t event,
   if (!buffer_.buffer(event, data)) {
     flush_buffer();
     buffer_.reset();
-    buffer_.buffer(event, data);
+    bool buffered = buffer_.buffer(event, data);
+    assert(buffered);
   }
 }
 

--- a/src/trace_buffer.h
+++ b/src/trace_buffer.h
@@ -19,7 +19,8 @@ public:
     size_t events_remaining;
   };
   trace_buffer_t(const size_t bytes);
-  bool buffer(const event_id_t event, std::span<const std::byte> data) noexcept;
+  [[nodiscard]] bool buffer(const event_id_t event,
+                            std::span<const std::byte> data) noexcept;
   drained_event_t drain_single();
 
   void reset();


### PR DESCRIPTION
## Summary
- mark `trace_buffer_t::buffer` as `[[nodiscard]]` to discourage ignoring allocation failures
- ensure `ndjson_trace_writer` checks the buffering result and asserts success

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bf1f7f637c83288a70765a769e81b6