### PR TITLE
Compute scoped trace start timestamp locally

### DIFF
--- a/src/scoped_trace.cpp
+++ b/src/scoped_trace.cpp
@@ -13,9 +13,10 @@ timestamp_t now_timestamp() {
 } // namespace
 
 scoped_trace_t::scoped_trace_t(trace_writer_t *writer, std::string_view label)
-    : writer_(writer), label_(label), start_(now_timestamp()) {
+    : writer_(writer), label_(label) {
   if (writer_) {
-    scope_trace_event_t ev{scope_token_t::beg, label_, start_};
+    timestamp_t start = now_timestamp();
+    scope_trace_event_t ev{scope_token_t::beg, label_, start};
     writer_->write(scope_trace_event_t::event_id,
                    std::span<const std::byte>(
                        reinterpret_cast<const std::byte *>(&ev), sizeof(ev)));

--- a/src/scoped_trace.h
+++ b/src/scoped_trace.h
@@ -14,7 +14,6 @@ public:
 private:
   trace_writer_t *writer_;
   std::string_view label_;
-  timestamp_t start_;
 };
 
 #define SIMPLETRACE_CONCAT_INNER(x, y) x##y


### PR DESCRIPTION
## Summary
- simplify `scoped_trace_t` by removing stored start timestamp
- compute start timestamp on the stack when emitting the begin event

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bf1f8b9c888328bd58ed5a7009cacc